### PR TITLE
docs: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Expect-CT middleware
 
+**The `Expect-CT` header has been deprecated and is no longer recommended.** [Chromium has enforced Certificate Transparency by default since version 107](https://chromestatus.com/feature/6244547273687040), making this header unnecessary. Firefox never implemented `Expect-CT`, relying on its own CT policy. Safari also does not support this header. This module will still be maintained but no new features will be added.
+
 The `Expect-CT` HTTP header tells browsers to expect Certificate Transparency. For more, see [this blog post](https://scotthelme.co.uk/a-new-security-header-expect-ct/) and the [article on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT).
 
 Usage:


### PR DESCRIPTION
The Expect-CT header has been deprecated by browsers. [MDN marks it as deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT), and Chromium has enforced Certificate Transparency by default since version 107.

This adds a prominent deprecation notice at the top of the README, similar to what the `hpkp` package already has, so users are aware when they come across this module.