### PR TITLE
chore: update minimum Node.js version to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "expect-ct"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
The `engines.node` field currently requires `>=10.0.0`, but Node.js 10 reached end-of-life in April 2021.

This updates the minimum to `>=18.0.0` to match:
- The CI test matrix (which starts at Node 18.x)
- Other packages in the helmetjs ecosystem (`helmet`, `hpkp`, `feature-policy`, `clearsitedata` all require `>=18.0.0`)